### PR TITLE
Support NPM Install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "beamup",
+  "version": "0.0.1",
+  "bin": "./cli/beamup",
+  "os" : [ "!win32" ]
+}


### PR DESCRIPTION
Fixes: https://github.com/Stremio/stremio-beamup/issues/21

Based on these docs:
- https://docs.npmjs.com/files/package.json#bin
- https://docs.npmjs.com/files/package.json#os

Expectations:
- use `npm install beamup -g`
- then just use `beamup` as a global command
- `npm install` should fail on Windows as it states this platform is unsupported in `package.json`

I have not tested it, and we can't easily test it until we merge and make a release on NPM.