### PR TITLE
Add additional arguments to config:set command

### DIFF
--- a/scripts/beamup-entry
+++ b/scripts/beamup-entry
@@ -38,8 +38,15 @@ then
 		exit 1
 	fi
 	case "$APP_NAME" in
-		${GITHUB_USER_HASHED}-*) dokku $1 $APP_NAME "$3";;
-		*)  exit 1 ;;
+		${GITHUB_USER_HASHED}-*)
+			if [ "$1" == "config:set" ] 
+			then
+				dokku $1 $APP_NAME "${@:3}"
+			else
+				dokku $1 $APP_NAME "$3"
+			fi ;;
+		*) 
+			exit 1 ;;
 	esac
 else
 	echo "unsupported command"


### PR DESCRIPTION
Currently, any environment variable setting happens separately and causes the container to restart.
I think adding the possibility of setting all the variables together, which is already supported by [dokku](https://dokku.com/docs/configuration/environment-variables/), will help those of us who set the env vars as part of their CI.

This is not a must since most of the users will only add a secret once and won't need to change it again but IMO it's nice to have.