### PR TITLE
add support for persistent storage

### DIFF
--- a/ansible/playbooks/swarm_apt.yml
+++ b/ansible/playbooks/swarm_apt.yml
@@ -61,6 +61,13 @@
         update_cache: yes
         cache_valid_time: 3600
 
+    - name: apt | Install fuse2fs
+      ansible.builtin.apt:
+        name: fuse2fs
+        state: present
+        update_cache: yes
+        cache_valid_time: 3600
+
     # Install sysstat for sar reporting
     - name: Install sysstat
       apt:

--- a/ansible/playbooks/swarm_apt.yml
+++ b/ansible/playbooks/swarm_apt.yml
@@ -47,6 +47,13 @@
         update_cache: yes
         cache_valid_time: 3600
 
+    - name: apt | Install autofs
+      apt:
+        name: autofs
+        state: present
+        update_cache: yes
+        cache_valid_time: 3600
+
     - name: Install nginx
       apt:
         name: nginx

--- a/ansible/playbooks/swarm_apt.yml
+++ b/ansible/playbooks/swarm_apt.yml
@@ -61,13 +61,6 @@
         update_cache: yes
         cache_valid_time: 3600
 
-    - name: apt | Install fuse2fs
-      ansible.builtin.apt:
-        name: fuse2fs
-        state: present
-        update_cache: yes
-        cache_valid_time: 3600
-
     # Install sysstat for sar reporting
     - name: Install sysstat
       apt:

--- a/swarm-syncer/beamup-sync-and-deploy
+++ b/swarm-syncer/beamup-sync-and-deploy
@@ -30,7 +30,7 @@ sleep 10
 docker stack deploy --detach=false --compose-file registry.yaml beamup_control
 sleep 50
 
-beamup-sync-swarm apps.yaml apps.conf
+beamup-sync-swarm apps.yaml apps.conf docker_volumes
 APPS_COUNT=`cat apps.yaml | grep image | wc -l`
 if [ $APPS_COUNT -gt 0 ] ; then
 	docker stack deploy --prune --compose-file apps.yaml beamup

--- a/swarm-syncer/beamup-sync-and-deploy
+++ b/swarm-syncer/beamup-sync-and-deploy
@@ -27,11 +27,11 @@ services:
 EOF
 docker stack rm --detach=false beamup_control
 sleep 10
-docker stack deploy --detach=false --compose-file registry.yaml beamup_control
+docker stack deploy --detach=false --compose-file registry.yaml beamup_control --detach=false
 sleep 50
 
-beamup-sync-swarm apps.yaml apps.conf docker_volumes
+sudo beamup-sync-swarm apps.yaml apps.conf docker_volumes
 APPS_COUNT=`cat apps.yaml | grep image | wc -l`
 if [ $APPS_COUNT -gt 0 ] ; then
-	docker stack deploy --prune --compose-file apps.yaml beamup
+	docker stack deploy --prune --compose-file apps.yaml beamup --detach=false
 fi

--- a/swarm-syncer/beamup-sync-swarm
+++ b/swarm-syncer/beamup-sync-swarm
@@ -10,6 +10,7 @@ const START_PORT = 8000
 const TOTAL_APP_LIMIT = 300
 const REGISTRY_URL = 'http://127.0.0.1:5000'
 const VOLUME_SIZE = 512 // in MB
+const VOLUME_MOUNT_DIR = `/mnt/beamup/volumes`;
 
 // https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete
 // Compose Specification is being used
@@ -68,7 +69,7 @@ const VOLUME_TMPL = (appName) => `   ${appName}_data:
         driver_opts:
           type: 'none'
           o: 'bind'
-          device: '/var/lib/beamup/${appName}/data'
+          device: '${VOLUME_MOUNT_DIR}/${appName}'
 `
 
 // https://github.com/docker-archive/for-aws/issues/104
@@ -124,11 +125,20 @@ server {
 function createVolume(appName) {
   if (!volumesDir) return;
   const volumePath = `${volumesDir}/${appName}_data`;
+  const mountDir = `${VOLUME_MOUNT_DIR}/${appName}`;
   if (!fs.existsSync(volumePath)) {
     try {
       execSync(`dd if=/dev/zero of="${volumePath}" bs=1M count=${VOLUME_SIZE}`);
+      // Create mount directory if it doesn't exist
+      if (!fs.existsSync(mountDir)) {
+        fs.mkdirSync(mountDir, { recursive: true });
+      }
+      // Set up loop device and mount
+      const losetupOut = execSync(`losetup --find --show "${volumePath}"`).toString().trim();
+      execSync(`mkfs.ext4 -F "${losetupOut}"`);
+      execSync(`mount "${losetupOut}" "${mountDir}"`);
     } catch (err) {
-      console.error(`Failed to create volume for ${appName}:`, err);
+      console.error(`Failed to create or mount volume for ${appName}:`, err);
     }
   }
 }

--- a/swarm-syncer/beamup-sync-swarm
+++ b/swarm-syncer/beamup-sync-swarm
@@ -3,13 +3,13 @@
 const fs = require('fs')
 const http = require('http')
 const https = require('https')
-const { execSync, spawn } = require('child_process');
+const { execSync } = require('child_process');
 const request = (http, args) => new Promise((resolve, reject) => http.request(args, resolve).on('error', reject).end(args.body))
 
 const START_PORT = 8000
 const TOTAL_APP_LIMIT = 300
 const REGISTRY_URL = 'http://127.0.0.1:5000'
-const VOLUME_SIZE = 512 // in MB
+const VOLUME_SIZE = '1GB'
 const VOLUME_MOUNT_DIR = `./beamup/volumes`;
 
 // https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete
@@ -39,7 +39,7 @@ const APP_TMPL = (appName, image, port) => `   ${appName}:
         ports:
           - '${port}:${port}'
         volumes:
-          - ${VOLUME_MOUNT_DIR}/${appName}:/persistent_data
+          - ${VOLUME_MOUNT_DIR}/${appName}:/persistant_data
 `
 
 const APP_DOCKER_TMPL = (appName, image, port) => `   ${appName}:
@@ -61,7 +61,7 @@ const APP_DOCKER_TMPL = (appName, image, port) => `   ${appName}:
         ports:
           - '${port}:${port}'
         volumes:
-          - ${VOLUME_MOUNT_DIR}/${appName}:/persistent_data
+          - ${VOLUME_MOUNT_DIR}/${appName}:/persistant_data
 `
 
 // https://github.com/docker-archive/for-aws/issues/104
@@ -114,24 +114,14 @@ server {
 
 `
 
-// Track FUSE mount processes to keep them alive
-const fuseProcesses = new Map();
-
 function createVolume(appName) {
   if (!volumesDir) return;
   const volumePath = `${volumesDir}/${appName}_data`;
   const mountDir = `${VOLUME_MOUNT_DIR}/${appName}`;
-  
   try {
     // Create volume file if it doesn't exist
     if (!fs.existsSync(volumePath)) {
-      console.log(`Creating volume for ${appName}...`);
-      execSync(`dd if=/dev/zero of="${volumePath}" bs=1M count=${VOLUME_SIZE}`, { stdio: 'inherit' });
-      
-      // Format the volume as ext4 using mke2fs from e2fsprogs
-      // mke2fs can format files directly without root access
-      console.log(`Formatting volume for ${appName}...`);
-      execSync(`/sbin/mke2fs -t ext4 -F "${volumePath}"`, { stdio: 'inherit' });
+      execSync(`dd if=/dev/zero of="${volumePath}" bs=1M count=0 seek=${VOLUME_SIZE}`);
     }
 
     // Create mount directory if it doesn't exist
@@ -140,77 +130,56 @@ function createVolume(appName) {
     }
 
     // Check if already mounted
+    const mounts = execSync('mount').toString();
+    if (mounts.includes(mountDir)) {
+      // Already mounted, skip
+      return;
+    }
+
+    // Set up loop device for the volume file
+    let loopdev = '';
     try {
-      const mountCheck = execSync('mount').toString();
-      if (mountCheck.includes(mountDir)) {
-        console.log(`Volume for ${appName} already mounted`);
-        return;
+      loopdev = execSync(`losetup -j "${volumePath}" | awk -F: '{print $1}'`).toString().trim();
+      if (!loopdev) {
+        loopdev = execSync(`losetup --find --show "${volumePath}"`).toString().trim();
       }
     } catch (err) {
-      // mount command failed, continue with mounting
+      console.error(`Failed to set up loop device for ${appName}:`, err);
+      return;
     }
 
-    // Mount using fuse2fs (FUSE-based ext4 filesystem)
-    console.log(`Mounting volume for ${appName} using FUSE...`);
-    
-    const fuseProcess = spawn('fuse2fs', [
-      '-o', 'rw,nonempty',
-      volumePath,
-      mountDir
-    ], {
-      detached: true,
-      stdio: 'ignore'
-    });
-
-    // Store the process so it doesn't get garbage collected
-    fuseProcesses.set(appName, fuseProcess);
-    
-    // Detach from parent process
-    fuseProcess.unref();
-
-
-    // Give it a moment to mount
-    execSync('sleep 0.5');
-
-    // Set permissions to 0777 so all users have write access
+    // Check if already formatted (has ext4)
+    let isFormatted = false;
     try {
-      execSync(`chmod 0777 "${mountDir}"`);
-      console.log(`Set permissions 0777 on ${mountDir}`);
-    } catch (permErr) {
-      console.error(`Failed to set permissions on ${mountDir}:`, permErr);
+      const blkid = execSync(`blkid -o value -s TYPE "${loopdev}"`).toString().trim();
+      if (blkid === 'ext4') isFormatted = true;
+    } catch (err) {
+      // Not formatted yet
+    }
+    if (!isFormatted) {
+      try {
+        execSync(`mkfs.ext4 -F "${loopdev}"`);
+      } catch (err) {
+        console.error(`Failed to format volume for ${appName}:`, err);
+        return;
+      }
     }
 
-    console.log(`Successfully mounted volume for ${appName}`);
-
+    // Mount if not already mounted
+    try {
+      execSync(`mount "${loopdev}" "${mountDir}"`);
+      // Set permissions to 0777 after mounting
+      fs.chmodSync(mountDir, 0o777);
+    } catch (err) {
+      // If already mounted, ignore; else log error
+      if (!/already mounted/.test(err.stderr?.toString() || '')) {
+        console.error(`Failed to mount volume for ${appName}:`, err);
+      }
+    }
   } catch (err) {
-    console.error(`Error creating/mounting volume for ${appName}:`, err);
+    console.error(`Error in createVolume for ${appName}:`, err);
   }
 }
-
-// Cleanup function to unmount all FUSE volumes
-function cleanupVolumes() {
-  console.log('Cleaning up FUSE volumes...');
-  fuseProcesses.forEach((process, appName) => {
-    try {
-      const mountDir = `${VOLUME_MOUNT_DIR}/${appName}`;
-      execSync(`fusermount -u "${mountDir}"`, { stdio: 'ignore' });
-      console.log(`Unmounted ${appName}`);
-    } catch (err) {
-      // Already unmounted or failed
-    }
-  });
-}
-
-// Handle graceful shutdown
-process.on('SIGINT', () => {
-  cleanupVolumes();
-  process.exit(0);
-});
-
-process.on('SIGTERM', () => {
-  cleanupVolumes();
-  process.exit(0);
-});
 
 async function getJSON(http, opts) {
 	const res = await request(http, opts)
@@ -276,7 +245,7 @@ const nginxCfg = process.argv[3]
 const volumesDir = process.argv[4]
 
 if (!(swarmCfg && swarmCfg.endsWith('.yaml') && nginxCfg && nginxCfg.endsWith('.conf'))) {
-	console.log('usage: beamup-sync-swarm <path to swarm yaml> <path to nginx config> [volumes directory]')
+	console.log('usage: beamup-sync-swarm <path to swarm yaml> <path to nginx config> <volumes directory>')
 	process.exit(1)
 }
 if (volumesDir) {
@@ -306,9 +275,4 @@ getConfigs().then(cfgs => {
 			})
 		})
 	}
-	console.log('Configuration complete. FUSE volumes mounted and ready.')
-}).catch(err => {
-	console.error('Error:', err);
-	cleanupVolumes();
-	process.exit(1);
 })

--- a/swarm-syncer/beamup-sync-swarm
+++ b/swarm-syncer/beamup-sync-swarm
@@ -3,19 +3,18 @@
 const fs = require('fs')
 const http = require('http')
 const https = require('https')
-const { execSync } = require('child_process');
+const { execSync, spawn } = require('child_process');
 const request = (http, args) => new Promise((resolve, reject) => http.request(args, resolve).on('error', reject).end(args.body))
 
 const START_PORT = 8000
 const TOTAL_APP_LIMIT = 300
 const REGISTRY_URL = 'http://127.0.0.1:5000'
 const VOLUME_SIZE = 512 // in MB
-const VOLUME_MOUNT_DIR = `beamup/volumes`;
+const VOLUME_MOUNT_DIR = `./beamup/volumes`;
 
 // https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete
 // Compose Specification is being used
 const HEADER = `services:`
-const VOLUMES_HEADER = `volumes:`
 
 // @TODO: assigning a random port may not be needed, just use the docker overlay network to reach the container (use it's IP)
 // @TODO: syslog for centralized log collection
@@ -40,7 +39,7 @@ const APP_TMPL = (appName, image, port) => `   ${appName}:
         ports:
           - '${port}:${port}'
         volumes:
-          - ${appName}_data:/persistant_data
+          - ${VOLUME_MOUNT_DIR}/${appName}:/persistent_data
 `
 
 const APP_DOCKER_TMPL = (appName, image, port) => `   ${appName}:
@@ -62,14 +61,7 @@ const APP_DOCKER_TMPL = (appName, image, port) => `   ${appName}:
         ports:
           - '${port}:${port}'
         volumes:
-          - ${appName}_data:/persistant_data
-`
-
-const VOLUME_TMPL = (appName) => `   ${appName}_data:
-        driver_opts:
-          type: 'none'
-          o: 'bind'
-          device: '${VOLUME_MOUNT_DIR}/${appName}'
+          - ${VOLUME_MOUNT_DIR}/${appName}:/persistent_data
 `
 
 // https://github.com/docker-archive/for-aws/issues/104
@@ -122,14 +114,24 @@ server {
 
 `
 
+// Track FUSE mount processes to keep them alive
+const fuseProcesses = new Map();
+
 function createVolume(appName) {
   if (!volumesDir) return;
   const volumePath = `${volumesDir}/${appName}_data`;
   const mountDir = `${VOLUME_MOUNT_DIR}/${appName}`;
+  
   try {
     // Create volume file if it doesn't exist
     if (!fs.existsSync(volumePath)) {
-      execSync(`dd if=/dev/zero of="${volumePath}" bs=1M count=${VOLUME_SIZE}`);
+      console.log(`Creating volume for ${appName}...`);
+      execSync(`dd if=/dev/zero of="${volumePath}" bs=1M count=${VOLUME_SIZE}`, { stdio: 'inherit' });
+      
+      // Format the volume as ext4 using mke2fs from e2fsprogs
+      // mke2fs can format files directly without root access
+      console.log(`Formatting volume for ${appName}...`);
+      execSync(`/sbin/mke2fs -t ext4 -F "${volumePath}"`, { stdio: 'inherit' });
     }
 
     // Create mount directory if it doesn't exist
@@ -138,54 +140,77 @@ function createVolume(appName) {
     }
 
     // Check if already mounted
-    const mounts = execSync('mount').toString();
-    if (mounts.includes(mountDir)) {
-      // Already mounted, skip
-      return;
-    }
-
-    // Set up loop device for the volume file
-    let loopdev = '';
     try {
-      loopdev = execSync(`losetup -j "${volumePath}" | awk -F: '{print $1}'`).toString().trim();
-      if (!loopdev) {
-        loopdev = execSync(`losetup --find --show "${volumePath}"`).toString().trim();
-      }
-    } catch (err) {
-      console.error(`Failed to set up loop device for ${appName}:`, err);
-      return;
-    }
-
-    // Check if already formatted (has ext4)
-    let isFormatted = false;
-    try {
-      const blkid = execSync(`blkid -o value -s TYPE "${loopdev}"`).toString().trim();
-      if (blkid === 'ext4') isFormatted = true;
-    } catch (err) {
-      // Not formatted yet
-    }
-    if (!isFormatted) {
-      try {
-        execSync(`mkfs.ext4 -F "${loopdev}"`);
-      } catch (err) {
-        console.error(`Failed to format volume for ${appName}:`, err);
+      const mountCheck = execSync('mount').toString();
+      if (mountCheck.includes(mountDir)) {
+        console.log(`Volume for ${appName} already mounted`);
         return;
       }
+    } catch (err) {
+      // mount command failed, continue with mounting
     }
 
-    // Mount if not already mounted
+    // Mount using fuse2fs (FUSE-based ext4 filesystem)
+    console.log(`Mounting volume for ${appName} using FUSE...`);
+    
+    const fuseProcess = spawn('fuse2fs', [
+      '-o', 'rw,nonempty',
+      volumePath,
+      mountDir
+    ], {
+      detached: true,
+      stdio: 'ignore'
+    });
+
+    // Store the process so it doesn't get garbage collected
+    fuseProcesses.set(appName, fuseProcess);
+    
+    // Detach from parent process
+    fuseProcess.unref();
+
+
+    // Give it a moment to mount
+    execSync('sleep 0.5');
+
+    // Set permissions to 0777 so all users have write access
     try {
-      execSync(`mount "${loopdev}" "${mountDir}"`);
-    } catch (err) {
-      // If already mounted, ignore; else log error
-      if (!/already mounted/.test(err.stderr?.toString() || '')) {
-        console.error(`Failed to mount volume for ${appName}:`, err);
-      }
+      execSync(`chmod 0777 "${mountDir}"`);
+      console.log(`Set permissions 0777 on ${mountDir}`);
+    } catch (permErr) {
+      console.error(`Failed to set permissions on ${mountDir}:`, permErr);
     }
+
+    console.log(`Successfully mounted volume for ${appName}`);
+
   } catch (err) {
-    console.error(`Error in createVolume for ${appName}:`, err);
+    console.error(`Error creating/mounting volume for ${appName}:`, err);
   }
 }
+
+// Cleanup function to unmount all FUSE volumes
+function cleanupVolumes() {
+  console.log('Cleaning up FUSE volumes...');
+  fuseProcesses.forEach((process, appName) => {
+    try {
+      const mountDir = `${VOLUME_MOUNT_DIR}/${appName}`;
+      execSync(`fusermount -u "${mountDir}"`, { stdio: 'ignore' });
+      console.log(`Unmounted ${appName}`);
+    } catch (err) {
+      // Already unmounted or failed
+    }
+  });
+}
+
+// Handle graceful shutdown
+process.on('SIGINT', () => {
+  cleanupVolumes();
+  process.exit(0);
+});
+
+process.on('SIGTERM', () => {
+  cleanupVolumes();
+  process.exit(0);
+});
 
 async function getJSON(http, opts) {
 	const res = await request(http, opts)
@@ -233,15 +258,14 @@ async function getConfigs() {
 	if (apps.length > TOTAL_APP_LIMIT) throw new Error('app limit exceeded')
 	const swarmHerokuishCfgs = apps.filter(app => !app.name.includes('docker')).map(app => APP_TMPL(app.name, app.fullImageName, app.port))
 	const swarmDockerfileCfgs = apps.filter(app => app.name.includes('docker')).map(app => APP_DOCKER_TMPL(app.name, app.fullImageName, app.port))
-  const swarmVolumeCfgs = apps.map(app => {
+  apps.forEach(app => {
     createVolume(app.name);
-    return VOLUME_TMPL(app.name);
   });
   const swarmCfgs = swarmHerokuishCfgs.concat(swarmDockerfileCfgs);
 //	const swarmCfgs = swarmHerokuishCfgs.concat(swarmDockerfileCfgs,networkCfg)
 	const nginxCfgs = apps.map(app => APP_NGINX_TMPL(app.name, app.port))
 	return {
-		swarm: [HEADER].concat(swarmCfgs,[VOLUMES_HEADER],swarmVolumeCfgs).join('\n'),
+		swarm: [HEADER].concat(swarmCfgs).join('\n'),
 		nginx: nginxCfgs.join('\n'),
 		apps
 	}
@@ -252,7 +276,7 @@ const nginxCfg = process.argv[3]
 const volumesDir = process.argv[4]
 
 if (!(swarmCfg && swarmCfg.endsWith('.yaml') && nginxCfg && nginxCfg.endsWith('.conf'))) {
-	console.log('usage: beamup-sync-swarm <path to swarm yaml> <path to nginx config>')
+	console.log('usage: beamup-sync-swarm <path to swarm yaml> <path to nginx config> [volumes directory]')
 	process.exit(1)
 }
 if (volumesDir) {
@@ -282,4 +306,9 @@ getConfigs().then(cfgs => {
 			})
 		})
 	}
+	console.log('Configuration complete. FUSE volumes mounted and ready.')
+}).catch(err => {
+	console.error('Error:', err);
+	cleanupVolumes();
+	process.exit(1);
 })

--- a/swarm-syncer/beamup-sync-swarm
+++ b/swarm-syncer/beamup-sync-swarm
@@ -10,7 +10,7 @@ const START_PORT = 8000
 const TOTAL_APP_LIMIT = 300
 const REGISTRY_URL = 'http://127.0.0.1:5000'
 const VOLUME_SIZE = 512 // in MB
-const VOLUME_MOUNT_DIR = `/mnt/beamup/volumes`;
+const VOLUME_MOUNT_DIR = `beamup/volumes`;
 
 // https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete
 // Compose Specification is being used
@@ -126,20 +126,64 @@ function createVolume(appName) {
   if (!volumesDir) return;
   const volumePath = `${volumesDir}/${appName}_data`;
   const mountDir = `${VOLUME_MOUNT_DIR}/${appName}`;
-  if (!fs.existsSync(volumePath)) {
-    try {
+  try {
+    // Create volume file if it doesn't exist
+    if (!fs.existsSync(volumePath)) {
       execSync(`dd if=/dev/zero of="${volumePath}" bs=1M count=${VOLUME_SIZE}`);
-      // Create mount directory if it doesn't exist
-      if (!fs.existsSync(mountDir)) {
-        fs.mkdirSync(mountDir, { recursive: true });
-      }
-      // Set up loop device and mount
-      const losetupOut = execSync(`losetup --find --show "${volumePath}"`).toString().trim();
-      execSync(`mkfs.ext4 -F "${losetupOut}"`);
-      execSync(`mount "${losetupOut}" "${mountDir}"`);
-    } catch (err) {
-      console.error(`Failed to create or mount volume for ${appName}:`, err);
     }
+
+    // Create mount directory if it doesn't exist
+    if (!fs.existsSync(mountDir)) {
+      fs.mkdirSync(mountDir, { recursive: true });
+    }
+
+    // Check if already mounted
+    const mounts = execSync('mount').toString();
+    if (mounts.includes(mountDir)) {
+      // Already mounted, skip
+      return;
+    }
+
+    // Set up loop device for the volume file
+    let loopdev = '';
+    try {
+      loopdev = execSync(`losetup -j "${volumePath}" | awk -F: '{print $1}'`).toString().trim();
+      if (!loopdev) {
+        loopdev = execSync(`losetup --find --show "${volumePath}"`).toString().trim();
+      }
+    } catch (err) {
+      console.error(`Failed to set up loop device for ${appName}:`, err);
+      return;
+    }
+
+    // Check if already formatted (has ext4)
+    let isFormatted = false;
+    try {
+      const blkid = execSync(`blkid -o value -s TYPE "${loopdev}"`).toString().trim();
+      if (blkid === 'ext4') isFormatted = true;
+    } catch (err) {
+      // Not formatted yet
+    }
+    if (!isFormatted) {
+      try {
+        execSync(`mkfs.ext4 -F "${loopdev}"`);
+      } catch (err) {
+        console.error(`Failed to format volume for ${appName}:`, err);
+        return;
+      }
+    }
+
+    // Mount if not already mounted
+    try {
+      execSync(`mount "${loopdev}" "${mountDir}"`);
+    } catch (err) {
+      // If already mounted, ignore; else log error
+      if (!/already mounted/.test(err.stderr?.toString() || '')) {
+        console.error(`Failed to mount volume for ${appName}:`, err);
+      }
+    }
+  } catch (err) {
+    console.error(`Error in createVolume for ${appName}:`, err);
   }
 }
 

--- a/swarm-syncer/beamup-sync-swarm
+++ b/swarm-syncer/beamup-sync-swarm
@@ -10,7 +10,7 @@ const START_PORT = 8000
 const TOTAL_APP_LIMIT = 300
 const REGISTRY_URL = 'http://127.0.0.1:5000'
 const VOLUME_SIZE = '1GB'
-const VOLUME_MOUNT_DIR = `./beamup/volumes`;
+const VOLUME_MOUNT_DIR = `/mnt/beamup`;
 
 // https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete
 // Compose Specification is being used
@@ -117,63 +117,27 @@ server {
 function createVolume(appName) {
   if (!volumesDir) return;
   const volumePath = `${volumesDir}/${appName}_data`;
-  const mountDir = `${VOLUME_MOUNT_DIR}/${appName}`;
   try {
-    // Create volume file if it doesn't exist
+    // If the volume file does not exist, create and format it
     if (!fs.existsSync(volumePath)) {
       execSync(`dd if=/dev/zero of="${volumePath}" bs=1M count=0 seek=${VOLUME_SIZE}`);
-    }
-
-    // Create mount directory if it doesn't exist
-    if (!fs.existsSync(mountDir)) {
-      fs.mkdirSync(mountDir, { recursive: true });
-    }
-
-    // Check if already mounted
-    const mounts = execSync('mount').toString();
-    if (mounts.includes(mountDir)) {
-      // Already mounted, skip
-      return;
-    }
-
-    // Set up loop device for the volume file
-    let loopdev = '';
-    try {
-      loopdev = execSync(`losetup -j "${volumePath}" | awk -F: '{print $1}'`).toString().trim();
-      if (!loopdev) {
-        loopdev = execSync(`losetup --find --show "${volumePath}"`).toString().trim();
-      }
-    } catch (err) {
-      console.error(`Failed to set up loop device for ${appName}:`, err);
-      return;
-    }
-
-    // Check if already formatted (has ext4)
-    let isFormatted = false;
-    try {
-      const blkid = execSync(`blkid -o value -s TYPE "${loopdev}"`).toString().trim();
-      if (blkid === 'ext4') isFormatted = true;
-    } catch (err) {
-      // Not formatted yet
-    }
-    if (!isFormatted) {
+      // Set up a loop device, format as ext4, set permissions, then detach
+      let loopdev = execSync(`losetup --find --show "${volumePath}"`).toString().trim();
+      const tmpMount = `/tmp/beamup-mnt-${appName}-${process.pid}`;
       try {
         execSync(`mkfs.ext4 -F "${loopdev}"`);
+        fs.mkdirSync(tmpMount, { recursive: true });
+        execSync(`mount "${loopdev}" "${tmpMount}"`);
+        execSync(`chmod 0777 "${tmpMount}"`);
+        execSync(`umount "${tmpMount}"`);
+        fs.rmdirSync(tmpMount);
       } catch (err) {
-        console.error(`Failed to format volume for ${appName}:`, err);
-        return;
-      }
-    }
-
-    // Mount if not already mounted
-    try {
-      execSync(`mount "${loopdev}" "${mountDir}"`);
-      // Set permissions to 0777 after mounting
-      fs.chmodSync(mountDir, 0o777);
-    } catch (err) {
-      // If already mounted, ignore; else log error
-      if (!/already mounted/.test(err.stderr?.toString() || '')) {
-        console.error(`Failed to mount volume for ${appName}:`, err);
+        // Try to clean up if mount fails
+        try { execSync(`umount "${tmpMount}"`); } catch (e) {}
+        try { fs.rmdirSync(tmpMount); } catch (e) {}
+        throw err;
+      } finally {
+        execSync(`losetup -d "${loopdev}"`);
       }
     }
   } catch (err) {

--- a/swarm-syncer/beamup-sync-swarm
+++ b/swarm-syncer/beamup-sync-swarm
@@ -3,15 +3,18 @@
 const fs = require('fs')
 const http = require('http')
 const https = require('https')
+const { execSync } = require('child_process');
 const request = (http, args) => new Promise((resolve, reject) => http.request(args, resolve).on('error', reject).end(args.body))
 
 const START_PORT = 8000
 const TOTAL_APP_LIMIT = 300
 const REGISTRY_URL = 'http://127.0.0.1:5000'
+const VOLUME_SIZE = 512 // in MB
 
 // https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete
 // Compose Specification is being used
 const HEADER = `services:`
+const VOLUMES_HEADER = `volumes:`
 
 // @TODO: assigning a random port may not be needed, just use the docker overlay network to reach the container (use it's IP)
 // @TODO: syslog for centralized log collection
@@ -35,6 +38,8 @@ const APP_TMPL = (appName, image, port) => `   ${appName}:
         command: /start web
         ports:
           - '${port}:${port}'
+        volumes:
+          - ${appName}_data:/persistant_data
 `
 
 const APP_DOCKER_TMPL = (appName, image, port) => `   ${appName}:
@@ -55,6 +60,15 @@ const APP_DOCKER_TMPL = (appName, image, port) => `   ${appName}:
           - PORT=${port}
         ports:
           - '${port}:${port}'
+        volumes:
+          - ${appName}_data:/persistant_data
+`
+
+const VOLUME_TMPL = (appName) => `   ${appName}_data:
+        driver_opts:
+          type: 'none'
+          o: 'bind'
+          device: '/var/lib/beamup/${appName}/data'
 `
 
 // https://github.com/docker-archive/for-aws/issues/104
@@ -107,6 +121,18 @@ server {
 
 `
 
+function createVolume(appName) {
+  if (!volumesDir) return;
+  const volumePath = `${volumesDir}/${appName}_data`;
+  if (!fs.existsSync(volumePath)) {
+    try {
+      execSync(`dd if=/dev/zero of="${volumePath}" bs=1M count=${VOLUME_SIZE}`);
+    } catch (err) {
+      console.error(`Failed to create volume for ${appName}:`, err);
+    }
+  }
+}
+
 async function getJSON(http, opts) {
 	const res = await request(http, opts)
 	if (res.statusCode !== 200) {
@@ -153,11 +179,15 @@ async function getConfigs() {
 	if (apps.length > TOTAL_APP_LIMIT) throw new Error('app limit exceeded')
 	const swarmHerokuishCfgs = apps.filter(app => !app.name.includes('docker')).map(app => APP_TMPL(app.name, app.fullImageName, app.port))
 	const swarmDockerfileCfgs = apps.filter(app => app.name.includes('docker')).map(app => APP_DOCKER_TMPL(app.name, app.fullImageName, app.port))
-	const swarmCfgs = swarmHerokuishCfgs.concat(swarmDockerfileCfgs)
+  const swarmVolumeCfgs = apps.map(app => {
+    createVolume(app.name);
+    return VOLUME_TMPL(app.name);
+  });
+  const swarmCfgs = swarmHerokuishCfgs.concat(swarmDockerfileCfgs);
 //	const swarmCfgs = swarmHerokuishCfgs.concat(swarmDockerfileCfgs,networkCfg)
 	const nginxCfgs = apps.map(app => APP_NGINX_TMPL(app.name, app.port))
 	return {
-		swarm: [HEADER].concat(swarmCfgs).join('\n'),
+		swarm: [HEADER].concat(swarmCfgs,[VOLUMES_HEADER],swarmVolumeCfgs).join('\n'),
 		nginx: nginxCfgs.join('\n'),
 		apps
 	}
@@ -165,9 +195,16 @@ async function getConfigs() {
 
 const swarmCfg = process.argv[2]
 const nginxCfg = process.argv[3]
+const volumesDir = process.argv[4]
+
 if (!(swarmCfg && swarmCfg.endsWith('.yaml') && nginxCfg && nginxCfg.endsWith('.conf'))) {
 	console.log('usage: beamup-sync-swarm <path to swarm yaml> <path to nginx config>')
 	process.exit(1)
+}
+if (volumesDir) {
+  if (!fs.existsSync(volumesDir)) {
+    fs.mkdirSync(volumesDir, { recursive: true });
+  }
 }
 getConfigs().then(cfgs => {
 	fs.writeFileSync(swarmCfg, cfgs.swarm)


### PR DESCRIPTION
now beamup-sync-and-deploy creates a fixed size virtual disk image and mount it to the docker container.

~the draw back is that the disk image will be created with that fixed size regardless of if the container actually uses it or not.~ 

TODO: 
- ~make the volumes auto mount on startup~
- use ansible to create create these files 
```
/etc/auto.indirect                                                                   
*       -fstype=ext4    :/home/beamup/docker_volumes/&_data

/etc/auto.master
/mnt/beamup     /etc/auto.indirect     --timeout=180
```


note: the volume is mounted to `/persistent_data` inside the container
