### PR TITLE
escape . in  subdomain's regex in nginx config

### DIFF
--- a/swarm-syncer/beamup-sync-swarm
+++ b/swarm-syncer/beamup-sync-swarm
@@ -74,7 +74,7 @@ upstream ${appName} {
 }
 
 server {
-        server_name ~^${appName}.;
+        server_name ~^${appName}\\.;
         access_log     /var/log/nginx/nginx.vhost.access.log;
         error_log      /var/log/nginx/nginx.vhost.error.log;
         #listen     443;


### PR DESCRIPTION
if you deploy an addon named "ADDON-NAME" then push another addon called "ADDON-NAME-XYZ" the requests to ADDON-NAME-XYZ will be forwarded to ADDON-NAME instead, since it's higher in the nginx config and will be matched first.

we use regix to match the subdomain 
using the regex `server_name ~^${appName}.;`
in our example it will be 'server_name ~^ADDON-NAME.;' where the dot at the end is supposed to be the dot at the end of the subdomain but since it's unescapped it's treated as the regex's special character that matches any character except line break, making it match our "ADDON-NAME-XYZ" 

NOTE: the fix has been tested with the local deployment and works fine  